### PR TITLE
use '>=' instead of '<=' in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     keywords='vsphere, backend, plugin, flocker, docker, python',
     url="https://github.com/vmware/vsphere-flocker-driver",
     install_requires=[
-        "pyvmomi=>5.5.0-2014.1.1",
+        "pyvmomi>=5.5.0-2014.1.1",
     ]
 )


### PR DESCRIPTION
I was unable to install this package via pip, with the following error message:

```
Complete output from command python setup.py egg_info:
    error in vSphere Flocker driver setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected version spec in pyvmomi=>5.5.0-2014.1.1 at =>5.5.0-2014.1.1
```

This was occurring because '<=' is not a valid version requirement specifier, but '>=' is