### PR TITLE
Handle case where device.backing.uuid is None

### DIFF
--- a/vsphere_flocker_plugin/vsphere_blockdevice.py
+++ b/vsphere_flocker_plugin/vsphere_blockdevice.py
@@ -206,12 +206,14 @@ class VsphereBlockDeviceAPI(object):
                       str(int(GiB(4).to_Byte().value)))
         return int(GiB(4).to_Byte().value)
 
-    def _normalize_uuid(self, uuid):
+    @staticmethod
+    def _normalize_uuid(uuid):
         """
-        Normalizes the input uuid to lower-case string without any white space or '-'
+        Normalizes the input uuid to lower-case string
+        without any white space or '-'
         """
-        uuid = uuid.translate(None, " -\n'")
-        uuid = uuid.lower()
+        if uuid:
+            uuid = uuid.translate(None, " -\n'").lower()
         return uuid
 
     def create_volume(self, dataset_id, size):

--- a/vsphere_flocker_plugin/vsphere_blockdevice.py
+++ b/vsphere_flocker_plugin/vsphere_blockdevice.py
@@ -7,7 +7,7 @@ from flocker.node.agents.blockdevice import (
     IBlockDeviceAPI, BlockDeviceVolume
 )
 from pyVmomi import vim, vmodl
-from pyVim.connect import SmartConnect, Disconnect
+from pyVim.connect import SmartConnect
 
 from twisted.python.filepath import FilePath
 from zope.interface import implementer
@@ -62,7 +62,7 @@ class VolumeDestroyFailure(Exception):
 
 class VolumeAttachFailure(Exception):
     """
-    attach volume failed 
+    attach volume failed
     """
 
 
@@ -104,7 +104,7 @@ def get_all_ips():
 
 class VsphereBlockDeviceVolume:
     """
-    Data object representing vsphere's BlockDeviceVolume 
+    Data object representing vsphere's BlockDeviceVolume
     """
 
     def __init__(self, blockDeviceVolume, path):
@@ -207,7 +207,7 @@ class VsphereBlockDeviceAPI(object):
 
     def _normalize_uuid(self, uuid):
         """
-        Normalizes the input uuid to lower-case string without any white space or '-'        
+        Normalizes the input uuid to lower-case string without any white space or '-'
         """
         uuid = uuid.translate(None, " -\n'")
         uuid = uuid.lower()
@@ -216,7 +216,7 @@ class VsphereBlockDeviceAPI(object):
     def create_volume(self, dataset_id, size):
         """
         Create a new volume.
-        Creates a new vmdk volume on vSphere datastore provided in the configuration     
+        Creates a new vmdk volume on vSphere datastore provided in the configuration
         :param UUID dataset_id: The Flocker dataset ID of the dataset on this
             volume.
         :param int size: The size of the new volume in bytes.


### PR DESCRIPTION
Some of the devices attached to VMs in my vsphere deployment apparently lack a backing uuid (ie. ```device.backing.uuid is None```). This ended up being an issue because this driver checks every VM to see if the device it needs is already attached elsewhere.

During this process an ```AttributeError``` was being raised in ```_list_vsphere_volumes``` on [line 586](https://github.com/vmware/vsphere-flocker-driver/blob/master/vsphere_flocker_plugin/vsphere_blockdevice.py#L586), specifically where ```_normalize_uuid``` was called. This method presumes uuid is a string  (and thus has .translate & .lower methods).

This issue manifested itself in ```vsphere.log``` with the following error:
```
2016-02-04 01:36:48,289 - vsphere_blockdevice - ERROR - list_volumes: List volumes failed with error: 'NoneType' object has no attribute 'translate'
```


Also rm'ed an unused import